### PR TITLE
Backfill missing lab metadata (7 files)

### DIFF
--- a/Instructions/Labs/LAB[PL-7003]_M00L00_Validate_lab_environment.md
+++ b/Instructions/Labs/LAB[PL-7003]_M00L00_Validate_lab_environment.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 0: Validate lab environment'
-    module: 'Module 0: Course Introduction'
+  title: 'Lab 0: Validate lab environment'
+  module: 'Module 0: Course Introduction'
+  description: If you are being provided with a tenant as a part of an instructor-led
+    training delivery, please note that the tenant is made available for the purpose
+    of supporting the hands-on labs in the instructor-led training.
+  duration: 38 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 0 - Validate lab environment

--- a/Instructions/Labs/LAB[PL-7003]_M01L01_Solution.md
+++ b/Instructions/Labs/LAB[PL-7003]_M01L01_Solution.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 1: Publisher and solution'
-    module: 'Module 1: Create tables in Dataverse'
+  title: 'Lab 1: Publisher and solution'
+  module: 'Module 1: Create tables in Dataverse'
+  description: In this lab, you will create a publisher and a solution.
+  duration: 94 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 1 - Publisher and solution

--- a/Instructions/Labs/LAB[PL-7003]_M01L02_Data_model.md
+++ b/Instructions/Labs/LAB[PL-7003]_M01L02_Data_model.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 2: Data model'
-    module: 'Module 1: Create tables in Dataverse'
+  title: 'Lab 2: Data model'
+  module: 'Module 1: Create tables in Dataverse'
+  description: In this lab, you will create Dataverse tables, columns, and relationships.
+  duration: 168 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 2 - Data model

--- a/Instructions/Labs/LAB[PL-7003]_M02L01_Create_mda.md
+++ b/Instructions/Labs/LAB[PL-7003]_M02L01_Create_mda.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Lab 3: Create a model-driven app'
-    module: 'Module 2: Get started with model-driven apps in Power Apps'
+  title: 'Lab 3: Create a model-driven app'
+  module: 'Module 2: Get started with model-driven apps in Power Apps'
+  description: In this lab, you will create model-driven app and add tables to the
+    app.
+  duration: 90 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 3 - Create a model-driven app

--- a/Instructions/Labs/LAB[PL-7003]_M03L01_Forms_views.md
+++ b/Instructions/Labs/LAB[PL-7003]_M03L01_Forms_views.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Lab 4: Configure forms and views'
-    module: 'Module 3: Configure forms, charts, and dashboards in model-driven apps'
+  title: 'Lab 4: Configure forms and views'
+  module: 'Module 3: Configure forms, charts, and dashboards in model-driven apps'
+  description: In this lab, you will configure forms and views for a model-driven
+    app.
+  duration: 172 minutes
+  level: 200
+  islab: true
 ---
 
 # Practice Lab 4 - Configure forms and views

--- a/Instructions/Labs/LAB[PL-7003]_M03L02_Configure_mda.md
+++ b/Instructions/Labs/LAB[PL-7003]_M03L02_Configure_mda.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 5: Configure a model-driven app'
-    module: 'Module 3: Configure forms, charts, and dashboards in model-driven apps'
+  title: 'Lab 5: Configure a model-driven app'
+  module: 'Module 3: Configure forms, charts, and dashboards in model-driven apps'
+  description: In this lab, you will configure a model-driven app.
+  duration: 62 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 5 - Configure a model-driven app

--- a/Instructions/Labs/LAB[PL-7003]_M04L01_Export_solution.md
+++ b/Instructions/Labs/LAB[PL-7003]_M04L01_Export_solution.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 6: Export solution'
-    module: 'Module 4: Manage solutions in Power Apps and Power Automate'
+  title: 'Lab 6: Export solution'
+  module: 'Module 4: Manage solutions in Power Apps and Power Automate'
+  description: In this lab, you will export the solution
+  duration: 80 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 6 - Export solution


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 7

- `Instructions/Labs/LAB[PL-7003]_M00L00_Validate_lab_environment.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7003]_M01L01_Solution.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7003]_M01L02_Data_model.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7003]_M02L01_Create_mda.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7003]_M03L01_Forms_views.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7003]_M03L02_Configure_mda.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7003]_M04L01_Export_solution.md` (description,duration,level,islab)
